### PR TITLE
feature: update eslint dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@lvce-editor/eslint-config": "^17.1.0",
-        "eslint": "^10.7.0",
+        "@lvce-editor/eslint-config": "^17.5.0",
+        "eslint": "^10.8.0",
         "prettier": "^3.8.3",
         "typescript": "^6.0.3"
       },
@@ -1366,19 +1366,6 @@
         }
       }
     },
-    "node_modules/@e18e/eslint-plugin/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
@@ -1952,9 +1939,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2978,11 +2965,14 @@
       }
     },
     "node_modules/@lvce-editor/eslint-config": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-17.1.0.tgz",
-      "integrity": "sha512-lmlYdyCFgw3RLz5FlFLjhfmiKZZMLrZP2fcyGIcs35LGlFkb/uDSub4RKBjPOPH0vl89NczKiO4tcoc7bL6gwA==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-17.5.0.tgz",
+      "integrity": "sha512-wjDaVd24PNVZdjbV8EcQYrbEWsKAJ9mak03EUIMTT6+tHVwlg9G1P2eDvqpxyMSmY3ywBKhAPigEjY2pwnCGUQ==",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@cspell/eslint-plugin": "10.0.1",
         "@e18e/eslint-plugin": "^0.5.1",
@@ -2990,14 +2980,15 @@
         "@eslint/js": "10.0.1",
         "@eslint/json": "2.0.1",
         "@eslint/markdown": "8.0.3",
-        "@lvce-editor/eslint-plugin-devcontainer": "17.1.0",
-        "@lvce-editor/eslint-plugin-e2e": "17.1.0",
-        "@lvce-editor/eslint-plugin-github-actions": "17.1.0",
-        "@lvce-editor/eslint-plugin-nvmrc": "17.1.0",
-        "@lvce-editor/eslint-plugin-regex": "17.1.0",
-        "@lvce-editor/eslint-plugin-rpc": "17.1.0",
-        "@lvce-editor/eslint-plugin-tsconfig": "17.1.0",
-        "@lvce-editor/eslint-plugin-virtual-dom": "17.1.0",
+        "@lvce-editor/eslint-plugin-devcontainer": "17.5.0",
+        "@lvce-editor/eslint-plugin-e2e": "17.5.0",
+        "@lvce-editor/eslint-plugin-extension-json": "17.5.0",
+        "@lvce-editor/eslint-plugin-github-actions": "17.5.0",
+        "@lvce-editor/eslint-plugin-nvmrc": "17.5.0",
+        "@lvce-editor/eslint-plugin-regex": "17.5.0",
+        "@lvce-editor/eslint-plugin-rpc": "17.5.0",
+        "@lvce-editor/eslint-plugin-tsconfig": "17.5.0",
+        "@lvce-editor/eslint-plugin-virtual-dom": "17.5.0",
         "eslint-plugin-jest": "29.15.4",
         "eslint-plugin-n": "18.2.1",
         "eslint-plugin-package-json": "1.5.0",
@@ -3012,9 +3003,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-devcontainer": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-17.1.0.tgz",
-      "integrity": "sha512-3q55rrK9/35lwmjFjgHs7w3RBFx4MNUZ+ed0s6P5F05slSwvt0QAqky7jKxfYvQJLOBClPnkTNPQRKWDgmZESA==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-17.5.0.tgz",
+      "integrity": "sha512-wNemW3CGngT/bRzB2ldVWW5++V/Xq549Hkbf7ZCc00XGxJhupZKTAYL3qCQvpdT5OJTUFc58Z9ddg42OLVENiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3022,16 +3013,26 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-e2e": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-17.1.0.tgz",
-      "integrity": "sha512-SphJpwEnzn9/JolZNiGe0dPPt73gHLis0/f8JoI1A7jFrhilHm76t1FN123ZgLvzqDK9mIoMw83LPXQTWtpc0A==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-17.5.0.tgz",
+      "integrity": "sha512-xGWeOY+aitgaKgxCVeRSJfEWMLf39u5wnq0uA3ZnZKFWXEHpZO3CaJi+9rw7KgFK7TcqgpxsaAHTENYEoabJHQ==",
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@lvce-editor/eslint-plugin-extension-json": {
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-extension-json/-/eslint-plugin-extension-json-17.5.0.tgz",
+      "integrity": "sha512-F7qOAYW1LhFntc2f5Yn1QQqArqgVLi1tW6vRNzgWIptlrZTib0cGFG4jKOL7ZgB5uDl0mZWlZ9q1Q1T055eWhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint/json": "2.0.1"
+      }
+    },
     "node_modules/@lvce-editor/eslint-plugin-github-actions": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-17.1.0.tgz",
-      "integrity": "sha512-Y7oaTDCdqOHEnDp2WjTk9eLSY8v9DzMRXip95Du4oR3hZGxa9jJvs0BTo3AuaxM8O+PN/qGeMVgFpouvmCbybg==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-17.5.0.tgz",
+      "integrity": "sha512-RhphHPbVQHqRu2yAZ/XnUdpP67BbPrIIrAvdkqSnitCVu65DDTTN1YVZMNdNv8cYue8V3V8eUMIf8WaNFBdJEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3040,46 +3041,33 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-nvmrc": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-17.1.0.tgz",
-      "integrity": "sha512-IkCHqK4tqA3cJzzMzxh2KRnU4cjZfpDX4RtXu5yCKnhjw7SOtFDB2z8RYb8R/OpSp+tJq3q/m7N2C/HIIxNygg==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-17.5.0.tgz",
+      "integrity": "sha512-mYcLlKt8Y2wKlM13xFXKaYDvKDOj/O5nnfj51oW7UTItROxtlD848eaXcxpLrH5iLTW5wC3G3Oz9ftwoGmqq7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^7.8.5"
       }
     },
-    "node_modules/@lvce-editor/eslint-plugin-nvmrc/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@lvce-editor/eslint-plugin-regex": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-17.1.0.tgz",
-      "integrity": "sha512-PqCksBaTWrUpdeCBrw0PJLCZTgK13X672Hn2RxAf93NuD7esrrOkYhu4b0PpHK/pK94+u/cM0o6OcH8LH9umaA==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-17.5.0.tgz",
+      "integrity": "sha512-PER04Hz35vvDFWXPK9wkSyAXB/H5aGGPE6i8nesbmGUP43fqT+7f9Kf5wzRUbUOdZ8HuFcnVQZALMbaEe1NcSg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-rpc": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-17.1.0.tgz",
-      "integrity": "sha512-ndssBmTP1olTtKO/8KCpIzibQR51GEOG3r0gTxk8CuuTNy1O/2+ikM+rw1jpOveTygK7B+wwYBrzZ3wIYbvsRQ==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-17.5.0.tgz",
+      "integrity": "sha512-7dfk74/7pFDK2fWnDK1M8OP46ehlMiK2TlOZYvsg3kU0J4dC0m7emnwvWKCgzyd/rNVPsTyqcz8PSM3U+4Lf4Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-tsconfig": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-17.1.0.tgz",
-      "integrity": "sha512-CVAXPVkoHnsTO4hU+P8cSApFTYVBdy1f+w38+06Z4Mp9sXC4A2VqDI8zXyhPG1XOtaLySpz9K8BpXzDWNUMtaw==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-17.5.0.tgz",
+      "integrity": "sha512-505lmJeM12Bq5eTZ5FMjB7qmbSu0Xi8bjVCbBSjyMNAVhCAiEUfuWXq0TeiJFeT40GzF88On0GPYHxS+dviWmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3087,9 +3075,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-virtual-dom": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-17.1.0.tgz",
-      "integrity": "sha512-821gJ8uqAeUAzDkhhoCvdiH11+7BvRt4zo+M/OdZmSnj/Dfqx9Uvj6YHRq8AupM57WL9EA7czgpJe8f89tnG1w==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-17.5.0.tgz",
+      "integrity": "sha512-sGiPawCOnR4E/8Bb+NTLlPpmvYS/t2vYrPwoG9/KVUq6gRnj3M34pQw2vsxP9A+PYig5LeL9TX5Wjj//DYVpXA==",
       "dev": true,
       "license": "MIT"
     },
@@ -5952,19 +5940,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -8067,9 +8042,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
-      "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -8079,7 +8054,7 @@
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/config-helpers": "^0.7.0",
         "@eslint/core": "^1.2.1",
         "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
@@ -8103,7 +8078,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -8139,19 +8114,6 @@
       },
       "peerDependencies": {
         "eslint": ">=6.0.0"
-      }
-    },
-    "node_modules/eslint-compat-utils/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/eslint-fix-utils": {
@@ -8233,19 +8195,6 @@
         "eslint": ">=6.0.0"
       }
     },
-    "node_modules/eslint-plugin-es-x/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/eslint-plugin-jest": {
       "version": "29.15.4",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.15.4.tgz",
@@ -8312,19 +8261,6 @@
         }
       }
     },
-    "node_modules/eslint-plugin-n/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/eslint-plugin-package-json": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-package-json/-/eslint-plugin-package-json-1.5.0.tgz",
@@ -8355,19 +8291,6 @@
         "@eslint/json": {
           "optional": true
         }
-      }
-    },
-    "node_modules/eslint-plugin-package-json/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/eslint-plugin-perfectionist": {
@@ -8464,19 +8387,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/eslint-plugin-sonarjs/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/eslint-plugin-unicorn": {
       "version": "71.1.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-71.1.0.tgz",
@@ -8523,19 +8433,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-plugin-unicorn/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/eslint-plugin-yml": {
@@ -10021,19 +9918,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
@@ -11170,19 +11054,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jest-util": {
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
@@ -11655,19 +11526,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/make-error": {
@@ -13125,19 +12983,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/package-json-validator/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/package-json-validator/node_modules/validate-npm-package-name": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
@@ -14022,29 +13867,13 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
       },
       "engines": {
         "node": ">=10"
@@ -14298,19 +14127,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/sort-package-json/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/sort-package-json/node_modules/tinyglobby": {
@@ -15030,19 +14846,6 @@
         }
       }
     },
-    "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/ts-jest/node_modules/type-fest": {
       "version": "4.41.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
@@ -15705,13 +15508,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "printWidth": 130
   },
   "devDependencies": {
-    "@lvce-editor/eslint-config": "^17.1.0",
-    "eslint": "^10.7.0",
+    "@lvce-editor/eslint-config": "^17.5.0",
+    "eslint": "^10.8.0",
     "prettier": "^3.8.3",
     "typescript": "^6.0.3"
   },


### PR DESCRIPTION
## Summary

- update `eslint` to 10.8.0
- update `@lvce-editor/eslint-config` to 17.5.0
- refresh the npm lockfile

## Validation

- `npm ci`
- build
- 7 test suites / 14 tests
- type-check
- lint
- E2E
- memory measurement
