### PR TITLE
fix: bundle extension API for transpiled modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2893,6 +2893,19 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@lvce-editor/api": {
+      "version": "9.18.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-9.18.1.tgz",
+      "integrity": "sha512-8tmQ7ztdBE8vDREu3VMjAagQrmNetk3vvguib9XdB1Nq8OAiVOFl1f+bR3biW+pbKTtGcv0s6Btjh9+f8U8jQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/command": "^2.0.0",
+        "@lvce-editor/rpc": "^6.4.0",
+        "@lvce-editor/rpc-registry": "^9.24.0",
+        "@lvce-editor/virtual-dom-worker": "^11.2.0"
+      }
+    },
     "node_modules/@lvce-editor/assert": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/assert/-/assert-1.9.0.tgz",
@@ -3565,6 +3578,16 @@
       "resolved": "https://registry.npmjs.org/@lvce-editor/verror/-/verror-1.7.0.tgz",
       "integrity": "sha512-+LGuAEIC2L7pbvkyAQVWM2Go0dAy+UWEui28g07zNtZsCBhm+gusBK8PNwLJLV5Jay+TyUYuwLIbJdjLLzqEBg==",
       "license": "MIT"
+    },
+    "node_modules/@lvce-editor/virtual-dom-worker": {
+      "version": "11.12.2",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/virtual-dom-worker/-/virtual-dom-worker-11.12.2.tgz",
+      "integrity": "sha512-ybsM8XzVs1CVtxIYafCAsKYvhWmgmV9ebb8eN9CgSaccZQJVqBPdI6bcJOf3vd3QPhBW6xZTjLhvcJds3qYD/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/constants": "^5.25.0"
+      }
     },
     "node_modules/@lvce-editor/web-socket-server": {
       "version": "2.1.0",
@@ -14793,6 +14816,7 @@
       "license": "MIT",
       "devDependencies": {
         "@babel/preset-typescript": "^7.29.7",
+        "@lvce-editor/api": "^9.18.1",
         "@lvce-editor/verror": "^1.7.0",
         "@rollup/plugin-babel": "^7.1.0",
         "@rollup/plugin-node-resolve": "^16.0.3",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -9,6 +9,7 @@
   "description": "",
   "devDependencies": {
     "@babel/preset-typescript": "^7.29.7",
+    "@lvce-editor/api": "^9.18.1",
     "@lvce-editor/verror": "^1.7.0",
     "@rollup/plugin-babel": "^7.1.0",
     "@rollup/plugin-node-resolve": "^16.0.3",

--- a/packages/build/src/build.js
+++ b/packages/build/src/build.js
@@ -2,6 +2,7 @@ import { execa } from 'execa'
 import { cp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { bundleJs } from './bundleJs.js'
+import { bundleExtensionApi } from './bundleExtensionApi.js'
 import { root } from './root.js'
 
 const dist = join(root, '.tmp', 'dist')
@@ -52,7 +53,7 @@ const getVersion = async () => {
 await rm(dist, { recursive: true, force: true })
 await mkdir(dist, { recursive: true })
 
-await bundleJs()
+await Promise.all([bundleJs(), bundleExtensionApi()])
 
 const version = await getVersion()
 

--- a/packages/build/src/bundleExtensionApi.js
+++ b/packages/build/src/bundleExtensionApi.js
@@ -1,0 +1,15 @@
+import { build } from 'esbuild'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { root } from './root.js'
+
+export const bundleExtensionApi = async () => {
+  await build({
+    bundle: true,
+    entryPoints: [fileURLToPath(import.meta.resolve('@lvce-editor/api'))],
+    external: ['electron', 'node:buffer', 'node:worker_threads'],
+    format: 'esm',
+    outfile: join(root, '.tmp', 'dist', 'dist', 'extensionApi.js'),
+    platform: 'browser',
+  })
+}

--- a/packages/typescript-compile-process/src/parts/RewriteLvceEditorApiImports/RewriteLvceEditorApiImports.ts
+++ b/packages/typescript-compile-process/src/parts/RewriteLvceEditorApiImports/RewriteLvceEditorApiImports.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const extensionApiRelativePath = join('.tmp', 'dist', 'dist', 'extension-api', 'index.js')
+const bundledExtensionApiName = 'extensionApi.js'
 const extensionApiEnvName = 'LVCE_EDITOR_EXTENSION_API_PATH'
 const extensionHostWorkerWorktreesName = 'extension-host-worker.worktrees'
 const maxParentDepth = 6
@@ -68,6 +69,7 @@ export const getCandidateExtensionApiPaths = (cwd = process.cwd(), moduleUrl = i
   const roots = [...getParentDirectories(cwd), ...getParentDirectories(modulePath)]
   const candidates = [
     process.env[extensionApiEnvName],
+    join(modulePath, bundledExtensionApiName),
     ...roots.map((root) => join(root, extensionApiRelativePath)),
     ...roots.flatMap(getSiblingExtensionApiPaths),
     ...roots.flatMap(getSiblingWorktreeExtensionApiPaths),

--- a/packages/typescript-compile-process/src/parts/RewriteLvceEditorApiImports/RewriteLvceEditorApiImports.ts
+++ b/packages/typescript-compile-process/src/parts/RewriteLvceEditorApiImports/RewriteLvceEditorApiImports.ts
@@ -1,9 +1,11 @@
+// cspell:ignore worktrees
 import { existsSync, readdirSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const extensionApiRelativePath = join('.tmp', 'dist', 'dist', 'extension-api', 'index.js')
 const extensionApiEnvName = 'LVCE_EDITOR_EXTENSION_API_PATH'
+const extensionHostWorkerWorktreesName = 'extension-host-worker.worktrees'
 const maxParentDepth = 6
 
 const getRemoteUrl = (path: string): string => {
@@ -39,6 +41,28 @@ const getSiblingExtensionApiPaths = (root: string): readonly string[] => {
   }
 }
 
+const getSiblingWorktreeExtensionApiPaths = (root: string): readonly string[] => {
+  try {
+    const entries = readdirSync(root, { withFileTypes: true })
+    const paths: string[] = []
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.name !== extensionHostWorkerWorktreesName) {
+        continue
+      }
+      const worktreesRoot = join(root, entry.name)
+      const worktrees = readdirSync(worktreesRoot, { withFileTypes: true })
+      for (const worktree of worktrees) {
+        if (worktree.isDirectory()) {
+          paths.push(join(worktreesRoot, worktree.name, extensionApiRelativePath))
+        }
+      }
+    }
+    return paths
+  } catch {
+    return []
+  }
+}
+
 export const getCandidateExtensionApiPaths = (cwd = process.cwd(), moduleUrl = import.meta.url): readonly string[] => {
   const modulePath = dirname(fileURLToPath(moduleUrl))
   const roots = [...getParentDirectories(cwd), ...getParentDirectories(modulePath)]
@@ -46,6 +70,7 @@ export const getCandidateExtensionApiPaths = (cwd = process.cwd(), moduleUrl = i
     process.env[extensionApiEnvName],
     ...roots.map((root) => join(root, extensionApiRelativePath)),
     ...roots.flatMap(getSiblingExtensionApiPaths),
+    ...roots.flatMap(getSiblingWorktreeExtensionApiPaths),
   ]
   const definedCandidates: string[] = []
   for (const candidate of candidates) {

--- a/packages/typescript-compile-process/test/RewriteLvceEditorApiImports.test.ts
+++ b/packages/typescript-compile-process/test/RewriteLvceEditorApiImports.test.ts
@@ -1,3 +1,4 @@
+// cspell:ignore worktrees
 import { expect, test } from '@jest/globals'
 import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -42,4 +43,17 @@ test('getExtensionApiPath - sibling project', async () => {
 
   const candidates = RewriteLvceEditorApiImports.getCandidateExtensionApiPaths(serverRoot)
   expect(RewriteLvceEditorApiImports.getExtensionApiPath(candidates)).toBe(extensionApiPath)
+})
+
+test('getExtensionApiPath - sibling project worktree', async () => {
+  const parent = await mkdtemp(join(tmpdir(), 'typescript-compile-process-'))
+  const serverRoot = join(parent, 'source-control-view.worktrees', 'direct-source-control-e2e')
+  const extensionHostWorkerRoot = join(parent, 'extension-host-worker.worktrees', 'extension-api')
+  const extensionApiPath = join(extensionHostWorkerRoot, '.tmp', 'dist', 'dist', 'extension-api', 'index.js')
+  await mkdir(serverRoot, { recursive: true })
+  await mkdir(join(extensionHostWorkerRoot, '.tmp', 'dist', 'dist', 'extension-api'), { recursive: true })
+  await writeFile(extensionApiPath, 'export {}')
+
+  const candidates = RewriteLvceEditorApiImports.getCandidateExtensionApiPaths(serverRoot)
+  expect(candidates).toContain(extensionApiPath)
 })

--- a/packages/typescript-compile-process/test/RewriteLvceEditorApiImports.test.ts
+++ b/packages/typescript-compile-process/test/RewriteLvceEditorApiImports.test.ts
@@ -2,7 +2,8 @@
 import { expect, test } from '@jest/globals'
 import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
+import { pathToFileURL } from 'node:url'
 import * as RewriteLvceEditorApiImports from '../src/parts/RewriteLvceEditorApiImports/RewriteLvceEditorApiImports.ts'
 
 test('rewriteLvceEditorApiImports - no extension api path', () => {
@@ -29,6 +30,17 @@ test('getExtensionApiPath - direct parent', async () => {
   await writeFile(extensionApiPath, 'export {}')
 
   const candidates = RewriteLvceEditorApiImports.getCandidateExtensionApiPaths(join(root, 'packages', 'server'))
+  expect(RewriteLvceEditorApiImports.getExtensionApiPath(candidates)).toBe(extensionApiPath)
+})
+
+test('getExtensionApiPath - bundled extension API', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'typescript-compile-process-'))
+  const modulePath = join(root, 'dist', 'index.js')
+  const extensionApiPath = join(dirname(modulePath), 'extensionApi.js')
+  await mkdir(dirname(modulePath), { recursive: true })
+  await writeFile(extensionApiPath, 'export {}')
+
+  const candidates = RewriteLvceEditorApiImports.getCandidateExtensionApiPaths(join(root, 'server'), pathToFileURL(modulePath).toString())
   expect(RewriteLvceEditorApiImports.getExtensionApiPath(candidates)).toBe(extensionApiPath)
 })
 


### PR DESCRIPTION
Bundles the LVCE extension API beside the compile process output so TypeScript fixtures importing `@lvce-editor/api` work directly in clean checkouts and CI. Keeps existing environment, sibling-build, and worktree fallbacks.