### PR TITLE
fix: normalize extension API remote URLs

### DIFF
--- a/packages/typescript-compile-process/src/parts/RewriteLvceEditorApiImports/RewriteLvceEditorApiImports.ts
+++ b/packages/typescript-compile-process/src/parts/RewriteLvceEditorApiImports/RewriteLvceEditorApiImports.ts
@@ -1,7 +1,7 @@
 // cspell:ignore worktrees
 import { existsSync, readdirSync } from 'node:fs'
 import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const extensionApiRelativePath = join('.tmp', 'dist', 'dist', 'extension-api', 'index.js')
 const bundledExtensionApiName = 'extensionApi.js'
@@ -10,7 +10,7 @@ const extensionHostWorkerWorktreesName = 'extension-host-worker.worktrees'
 const maxParentDepth = 6
 
 const getRemoteUrl = (path: string): string => {
-  return `/remote${path}`
+  return `/remote/${pathToFileURL(path).toString().slice(8)}`
 }
 
 const getParentDirectories = (path: string): readonly string[] => {

--- a/packages/typescript-compile-process/test/RewriteLvceEditorApiImports.test.ts
+++ b/packages/typescript-compile-process/test/RewriteLvceEditorApiImports.test.ts
@@ -19,7 +19,7 @@ test('rewriteLvceEditorApiImports', async () => {
 
   const code = `import { activate } from '@lvce-editor/api'`
   expect(RewriteLvceEditorApiImports.rewriteLvceEditorApiImports(code, extensionApiPath)).toBe(
-    `import { activate } from '/remote${extensionApiPath}'`,
+    `import { activate } from '/remote/${pathToFileURL(extensionApiPath).toString().slice(8)}'`,
   )
 })
 


### PR DESCRIPTION
Normalize rewritten extension API paths as remote file URLs so generated imports are portable on Windows. Includes platform-aware rewrite coverage.